### PR TITLE
Support MP3 input files

### DIFF
--- a/src/audio_transfer_learning.py
+++ b/src/audio_transfer_learning.py
@@ -14,7 +14,7 @@ from sklearn.neighbors import KNeighborsClassifier
 from sklearn import decomposition
 
 import vggish_input, vggish_slim, vggish_params, utils
-from utils import wavefile_to_waveform
+from utils import audiofile_to_waveform
 
 try:
     import openl3
@@ -118,7 +118,7 @@ def extract_other_features(paths, path2gt, model_type):
             emb = extracted_features['max_pool'] # or choose any other layer, for example: emb = taggram
             # Documentation: https://github.com/jordipons/musicnn/blob/master/DOCUMENTATION.md
         elif model_type == 'openl3':
-            wave, sr = wavefile_to_waveform(config['audio_folder'] + p, 'openl3')
+            wave, sr = audiofile_to_waveform(config['audio_folder'] + p, 'openl3')
             emb, _ = openl3.get_embedding(wave, sr, hop_size=1, model=model, verbose=False)
 
         if first_audio:

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,4 +1,6 @@
 import os
+import warnings
+import librosa
 import numpy as np
 import matplotlib.pyplot as plt
 import soundfile as sf
@@ -76,8 +78,11 @@ def matrix_visualization(matrix,title=None):
     plt.show()
 
 
-def wavefile_to_waveform(wav_file, features_type):
-    data, sr = sf.read(wav_file)
+def audiofile_to_waveform(audio_file, features_type):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        data, sr = librosa.load(audio_file)
+
     if features_type == 'vggish':
         tmp_name = str(int(np.random.rand(1)*1000000)) + '.wav'
         sf.write(tmp_name, data, sr, subtype='PCM_16')

--- a/src/vggish_input.py
+++ b/src/vggish_input.py
@@ -21,7 +21,7 @@ from scipy.io import wavfile
 
 import mel_features
 import vggish_params
-from utils import wavefile_to_waveform
+from utils import audiofile_to_waveform
 
 
 def waveform_to_examples(data, sample_rate):
@@ -81,6 +81,6 @@ def wavfile_to_examples(wav_file):
   Returns:
     See waveform_to_examples.
   """
-  samples, sr = wavefile_to_waveform(wav_file, 'vggish')
+  samples, sr = audiofile_to_waveform(wav_file, "vggish")
 
   return waveform_to_examples(samples, sr)


### PR DESCRIPTION
Hi, thanks for this project. This PR adds support for .mp3 audio files as input. I'm not sure how best to test this change, but I did at least observe that a reasonably successful classifier could be created using this change with .mp3 input.

- Alter `wavefile_to_waveform` so that it is able to read .mp3 input as well as .wav
- Change the name of that function to `audiofile_to_waveform`